### PR TITLE
FIX: Broken build due to QStyle not being declared

### DIFF
--- a/processdialog.cpp
+++ b/processdialog.cpp
@@ -3,6 +3,7 @@
 #include "ui_processdialog.h"
 #include "waifu2xconvertercppoptions.h"
 #include <QDir>
+#include <QStyle>
 #include <QtDebug>
 
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
The build fails in `processdialog.cpp:112` at `style()->standardPixmap(QStyle::SP_FileIcon)` with Qt 5.11.1. I guess some headers have changed so that `QStyle` no longer is included.